### PR TITLE
Small hashing optimizations

### DIFF
--- a/Kitsune/ClubPenguin/Hashing.php
+++ b/Kitsune/ClubPenguin/Hashing.php
@@ -6,12 +6,20 @@ final class Hashing {
 
 	private static $characterSet = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM0123456789`~@#$()_+-={}|[]:,.";
 	
+	public static function generateRandomInt($min, $max) {
+		if(function_exists('random_int')) { //PHP7
+			return random_int($min, $max);
+		} else {
+			return mt_rand($min, $max);
+		}
+	}
+	
 	public static function generateRandomKey() {
-		$keyLength = mt_rand(7, 10);
+		$keyLength = self::generateRandomInt(7, 10);
 		$randomKey = "";
 		
 		foreach(range(0, $keyLength) as $currentLength) {
-			$randomKey .= substr(self::$characterSet, mt_rand(0, strlen(self::$characterSet)), 1);
+			$randomKey .= substr(self::$characterSet, self::generateRandomInt(0, strlen(self::$characterSet)), 1);
 		}
 		
 		return $randomKey;

--- a/Kitsune/ClubPenguin/Hashing.php
+++ b/Kitsune/ClubPenguin/Hashing.php
@@ -7,7 +7,13 @@ final class Hashing {
 	private static $characterSet = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM0123456789`~@#$()_+-={}|[]:,.";
 	
 	public static function generateRandomInt($min, $max) {
-		if(function_exists('random_int')) { //PHP7
+		static $csrngSupported;
+
+		if(is_null($csrngSupported)) {
+			$csrngSupported = function_exists('random_int');
+		}
+
+		if($csrngSupported) { //PHP7
 			return random_int($min, $max);
 		} else {
 			return mt_rand($min, $max);
@@ -17,10 +23,10 @@ final class Hashing {
 	public static function generateRandomKey() {
 		$keyLength = self::generateRandomInt(7, 10);
 		$randomKey = "";
-		
-		foreach(range(0, $keyLength) as $currentLength) {
-			$randomKey .= substr(self::$characterSet, self::generateRandomInt(0, strlen(self::$characterSet)), 1);
-		}
+
+		srand(self::generateRandomInt(0, 2147483647));
+		$strRandomized = str_shuffle(self::$characterSet);
+		$randomKey = substr($strRandomized, 0, $keyLength);
 		
 		return $randomKey;
 	}

--- a/Kitsune/ClubPenguin/Hashing.php
+++ b/Kitsune/ClubPenguin/Hashing.php
@@ -7,7 +7,7 @@ final class Hashing {
 	private static $characterSet = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM0123456789`~@#$()_+-={}|[]:,.";
 	
 	public static function generateRandomInt($min, $max) {
-		static $csrngSupported;
+		static $csrngSupported; //Static to save CPU cycles
 
 		if(is_null($csrngSupported)) {
 			$csrngSupported = function_exists('random_int');


### PR DESCRIPTION
This removes an unnecessary foreach loop that carried out the function of a str_shuffle from Hashing.php, and uses random_int for crypto when available instead of mt_rand.
