### PR TITLE
Clean up event system

### DIFF
--- a/Kitsune/ClubPenguin/ClubPenguin.php
+++ b/Kitsune/ClubPenguin/ClubPenguin.php
@@ -59,7 +59,7 @@ abstract class ClubPenguin extends Kitsune\Kitsune {
 		
 		$removePlugin = false;
 		
-		if(empty($this->worldHandlers) && $pluginObject->loginServer !== true) {		
+		if(empty($this->worldHandlers) && $pluginObject->loginServer !== true && $pluginObject->eventBinder !== true) {
 			unset($this->loadedPlugins[$pluginClass]);
 			
 			unset($pluginObject);

--- a/Kitsune/ClubPenguin/Plugins/Base/Plugin.php
+++ b/Kitsune/ClubPenguin/Plugins/Base/Plugin.php
@@ -18,6 +18,8 @@ abstract class Plugin implements IPlugin {
 	public $worldStalker = false;
 	
 	public $loginServer = false;
+
+	public $eventBinder = false;
 	
 	protected $server = null;
 	
@@ -26,21 +28,19 @@ abstract class Plugin implements IPlugin {
 	protected function __construct($pluginName) {
 		$readableName = basename($pluginName);
 		
-		if($this->server == null) {
-			Logger::Warn("$readableName didn't set a server object");
+		if($this->eventBinder !== true) {
+			if(empty($this->xmlHandlers)) {
+				$this->loginStalker = true;
+			}
+
+			if(empty($this->worldHandlers)) {
+				$this->worldStalker = true;
+			}
 		}
-		
-		if(empty($this->xmlHandlers)) {
-			$this->loginStalker = true;
-		}
-		
-		if(empty($this->worldHandlers)) {
-			$this->worldStalker = true;
-		}
-		
+
 		$this->pluginName = $readableName;
 	}
-	
+
 	abstract public function onReady();
 	
 	public function handleXmlPacket($penguin, $beforeCall = true) {

--- a/Kitsune/ClubPenguin/Plugins/Events/DCNotice.php
+++ b/Kitsune/ClubPenguin/Plugins/Events/DCNotice.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kitsune\ClubPenguin\Plugins\Events;
+
+use Kitsune\Events;
+use Kitsune\Logging\Logger;
+use Kitsune\ClubPenguin\Packets\Packet;
+use Kitsune\ClubPenguin\Plugins\Base\Plugin;
+
+final class DCNotice extends Plugin {
+
+	public $worldHandlers = array(null);
+
+	public $xmlHandlers = array(null);
+
+	public $eventBinder = true;
+
+	public function __construct($server) {
+	}
+
+	public function onReady() {
+		parent::__construct(__CLASS__);
+		Events::Append('leave', array($this, 'logPenguinLeave'));
+	}
+
+	public function logPenguinLeave($penguin) {
+		$username = $penguin->username;
+
+		Logger::Notice($username . ' is leaving the server');
+	}
+
+}
+
+?>

--- a/Kitsune/ClubPenguin/World.php
+++ b/Kitsune/ClubPenguin/World.php
@@ -389,6 +389,7 @@ final class World extends ClubPenguin {
 	}
 	
 	protected function removePenguin($penguin) {
+		Events::Fire("quit", $penguin);
 		// Remove the penguin from igloo maps if included.
 		if(isset($this->openIgloos[$penguin->id])) {
 			unset($this->openIgloos[$penguin->id]);

--- a/Kitsune/ClubPenguin/World.php
+++ b/Kitsune/ClubPenguin/World.php
@@ -389,7 +389,7 @@ final class World extends ClubPenguin {
 	}
 	
 	protected function removePenguin($penguin) {
-		Events::Fire("quit", $penguin);
+		Events::Fire("leave", $penguin);
 		// Remove the penguin from igloo maps if included.
 		if(isset($this->openIgloos[$penguin->id])) {
 			unset($this->openIgloos[$penguin->id]);

--- a/Kitsune/Events.php
+++ b/Kitsune/Events.php
@@ -46,7 +46,7 @@ final class Events {
 	}
 
 	// Interval in seconds
-	public static function AppendInterval($interval, $callable) {
+	public static function AppendInterval($interval, $callable) { //Timed events do not fire on first tick after adding
 		$eventArray = [$callable, $interval, null];
 		array_push(self::$timedEvents, $eventArray);
 
@@ -57,27 +57,24 @@ final class Events {
 	// Adds event and/or event callable
 	public static function Append($event, $callable) {
 		if(array_key_exists($event, self::$events)) {
-			array_push(self::$events, $callable);
+			array_push(self::$events[$event], $callable);
 		} else {
 			self::$events[$event] = array($callable);
 		}
 
-		$callableIndex = array_search($callable, self::$events);
+		$callableIndex = array_search($callable, self::$events[$event]);
 
 		return $callableIndex;
 	}
 
-	// Removes event, or event callable (by index)
-	public static function Remove($event, $callableIndex = null) {
+	// Removes event callable (by index)
+	public static function Remove($event, $callableIndex) {
 		if(array_key_exists($event, self::$events)) {
-			if($callableIndex === null) {
-				unset(self::$events[$event]);
+
+			if(array_key_exists($callableIndex, self::$events[$event])) {
+				unset(self::$events[$event][$callableIndex]);
 			} else {
-				if(array_key_exists($callableIndex, self::$events[$event])){
-					unset(self::$events[$event][$callableIndex]);
-				} else {
-					return false;
-				}
+				return false;
 			}
 
 			return true;

--- a/Kitsune/Events.php
+++ b/Kitsune/Events.php
@@ -86,9 +86,13 @@ final class Events {
 	public static function Fire($event, $data = null) {
 		if(array_key_exists($event, self::$events)) {
 			foreach(self::$events[$event] as $eventCallable) {
-				call_user_func($eventCallable, $data);
+				$canContinue = call_user_func($eventCallable, $data);
+				if(!$canContinue) {
+					return false; //Callable says deny the action
+				}
 			}
 		}
+		return true; //Action can continue
 	}
 
 	// Clears the entire event array

--- a/Kitsune/Kitsune.php
+++ b/Kitsune/Kitsune.php
@@ -12,7 +12,11 @@ abstract class Kitsune extends Spirit {
 	public $penguins = array();
 	
 	protected function handleAccept($socket) {
-		Events::Fire("accept", $socket);
+		$Accept = Events::Fire("accept", $socket);
+		if(!$Accept) {
+			Logger::Notice("Plugin denied client accept");
+			$this->removeClient($socket);
+		}
 
 		$newPenguin = new Penguin($socket);
 		$this->penguins[$socket] = $newPenguin;
@@ -26,7 +30,10 @@ abstract class Kitsune extends Spirit {
 	}
 	
 	protected function handleReceive($socket, $data) {
-		Events::Fire("receive", [$socket, $data]);
+		$Receive = Events::Fire("receive", [$socket, $data]);
+		if(!$Receive) { //Good for filters to tell server to ignore packet
+			return false;
+		}
 
 		$chunkedArray = explode("\0", $data);
 		array_pop($chunkedArray);

--- a/Kitsune/Kitsune.php
+++ b/Kitsune/Kitsune.php
@@ -46,7 +46,10 @@ abstract class Kitsune extends Spirit {
 			if(Packet::$IsXML) {
 				$this->handleXmlPacket($socket);
 			} else {
-				$this->handleWorldPacket($socket);
+				$Packet = Events::Fire('packet', $socket);
+				if($Packet !== false) {
+					$this->handleWorldPacket($socket);
+				}
 			}
 		}
 


### PR DESCRIPTION
This fixes the behavior of Events::Append, removes Events::Remove's duplicate functionality of Events::Flush, adds a new Event type of plugin, adds an event trigger for penguins disconnecting (NOT clients disconnecting), and creates an example Event plugin called DCNotice.
