### PR TITLE
Single Database Connection

### DIFF
--- a/Kitsune/ClubPenguin/ClubPenguin.php
+++ b/Kitsune/ClubPenguin/ClubPenguin.php
@@ -212,7 +212,8 @@ abstract class ClubPenguin extends Kitsune\Kitsune {
 		$penguin = $this->penguins[$socket];
 
 		if($penguin->handshakeStep === "versionCheck") {
-			$penguin->send("<msg t='sys'><body action='rndK' r='-1'><k>e4a2dbcca10a7246817a83cd" . $penguin->username . "</k></body></msg>");
+			$penguin->randomKey = "e4a2dbcca10a7246817a83cd" . $penguin->username;
+			$penguin->send("<msg t='sys'><body action='rndK' r='-1'><k>" . $penguin->randomKey . "</k></body></msg>");
 			$penguin->handshakeStep = "randomKey";
 
 			return true;

--- a/Kitsune/ClubPenguin/ClubPenguin.php
+++ b/Kitsune/ClubPenguin/ClubPenguin.php
@@ -26,9 +26,6 @@ abstract class ClubPenguin extends Kitsune\Kitsune {
 	public $loadedPlugins = array();
 	
 	protected function __construct($loadPlugins = true, $pluginsDirectory = "Kitsune/ClubPenguin/Plugins/") {
-		$tempDatabase = new Kitsune\Database();
-		unset($tempDatabase);
-
 		$this->databaseManager = new DatabaseManager();
 		
 		if($loadPlugins === true) {

--- a/Kitsune/ClubPenguin/Hashing.php
+++ b/Kitsune/ClubPenguin/Hashing.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kitsune\ClubPenguin;
+
+final class Hashing {
+	
+	public static function encryptPassword($password, $md5 = true) {
+		if($md5 !== false) {
+			$password = md5($password);
+		}
+		
+		$hash = substr($password, 16, 16) . substr($password, 0, 16);
+		return $hash;
+	}
+
+	public static function getLoginHash($password, $randomKey) {		
+		$hash = self::encryptPassword($password, false);
+		$hash .= $randomKey;
+		$hash .= "a1ebe00441f5aecb185d0ec178ca2305Y(02.>'H}t\":E1_root";
+		$hash = self::encryptPassword($hash);
+		
+		return $hash;
+	}
+	
+}
+
+?>

--- a/Kitsune/ClubPenguin/Login.php
+++ b/Kitsune/ClubPenguin/Login.php
@@ -33,9 +33,9 @@ final class Login extends ClubPenguin {
 		}
 		
 		$penguinData = $penguin->database->getColumnsByName($username, array("ID", "Username", "Password", "SWID", "Email", "Banned"));
-		$encryptedPassword = $penguinData["Password"];
+		$encryptedPassword = Hashing::getLoginHash($penguinData["Password"], $penguin->randomKey);
 		
-		if(password_verify($password, $encryptedPassword) !== true) {
+		if(password_verify($password, $penguinData["Password"]) !== true) {
 			$penguin->send("%xt%e%-1%101%");
 			return $this->removePenguin($penguin);
 		} elseif($penguinData["Banned"] > strtotime("now") || $penguinData["Banned"] == "perm") {

--- a/Kitsune/ClubPenguin/World.php
+++ b/Kitsune/ClubPenguin/World.php
@@ -2,6 +2,7 @@
 
 namespace Kitsune\ClubPenguin;
 
+use Kitsune\Events;
 use Kitsune\Logging\Logger;
 use Kitsune\ClubPenguin\Handlers;
 use Kitsune\ClubPenguin\Packets\Packet;


### PR DESCRIPTION
Adjusted the **DatabaseManager** class so that it only uses a single database connection for all the users on the server.

The manager automatically closes the database connection if it isn't being used, and automatically creates one when it needs to.

I only briefly tested it and it seems to work fine. My main concern is that some users (particularly bots) may avoid being timed out and therefore force the connection to stay open which may result in the MySQL server automatically terminating it after a certain period of time.

https://dev.mysql.com/doc/refman/5.7/en/gone-away.html